### PR TITLE
fix: pruning branches

### DIFF
--- a/bashrc/git.fn
+++ b/bashrc/git.fn
@@ -108,7 +108,7 @@ function __set_git_aliases() {
 	alias t='git tag -l -n1'
 	alias ft='git fetch'
 	alias show='git show --name-status --show-signature'
-	alias gp='git branch -vv | grep ": gone]"|  grep -v "\*" | awk "{ print $1; }" | xargs -r git branch -d'
+	alias gp='git fetch --prune; git branch -vv | grep ": gone]" |  grep -v "\*" | awk '\''{ print $1; }'\'' | xargs -r git branch -D'
 	alias gt='git fetch --prune-tags'
 }
 


### PR DESCRIPTION
RCA:
- git fetch was missing
- awk requires a single quote & not double quote

FIX:
- added a git fetch with prune before deleting the branch
- escaped the single quote for awk to work