### PR TITLE
fix: make alaises were not created

### DIFF
--- a/bashrc/code.fn
+++ b/bashrc/code.fn
@@ -52,7 +52,9 @@ function __set_clang_aliases() {
 			;;
 	esac
 	export CSCOPE_EDITOR="vim"
+}
 
+function __set_make_aliases() {
 	alias mc='make clean'
 	alias mcm='make clean; make'
 }

--- a/bashrc/my.bashrc
+++ b/bashrc/my.bashrc
@@ -30,6 +30,7 @@ __set_ls_aliases
 # language prefs
 __set_editor_aliases
 __set_clang_aliases
+__set_make_aliases
 
 # source control prefs
 __set_git_aliases


### PR DESCRIPTION
RCA
- make aliases were embedded inside the ctags aliases
- since ctags & cscope were not present the alias function errored out
- thus make aliases were not created

FIX
- separated make aliases into its own functions
- called them from the main bashrc script